### PR TITLE
Add checks if not gnome environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,13 @@ To set up the environment and deploy the applications, follow these steps:
    - Installs **Fairwinds Goldilocks** for resource recommendation.
    - Deploys the QoS pods and the traffic generator application.
 
-   To run the script, execute the following command:
+   To run the script, ensure the setup.sh is executable: 
+
+   ```bash
+   chmod +x setup.sh
+   ```
+
+   Now you should be able to execute the following command:
 
    ```bash
    ./setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -112,16 +112,22 @@ open_traffic_generator_terminal() {
 
     log "Found Traffic Generator pod: $pod_name. Opening terminal to SSH into it."
 
-    gnome-terminal -- bash -c "kubectl exec -n qos -it $pod_name -- bash; exec bash"
-    
-    log "In the terminal, you can now run the following command to start the stress test:
-stress --cpu 1 --vm 1 --vm-bytes 500M --timeout 1200s"
+    if command -v gnome-terminal &> /dev/null; then
+        gnome-terminal -- bash -c "kubectl exec -n qos -it $pod_name -- bash; exec bash"
+        else
+            log "Open a new terminal and run 'kubectl exec -n qos -it $pod_name -- bash'"
+    fi
+
+    log "In the terminal, you can now run the following command to start the stress test: stress --cpu 1 --vm 1 --vm-bytes 500M --timeout 1200s"
 }
 
 open_goldilocks_dashboard() {
-    log "Opening Goldilocks dashboard in the browser at http://localhost:8080"
-    
-    xdg-open http://localhost:8080
+    if command -v xdg-open &> /dev/null; then
+        log "Opening Goldilocks dashboard in the browser at http://localhost:8080"
+        xdg-open http://localhost:8080
+    else
+        log "Open Goldilocks dashbord in your browser at http://localhost:8080"
+    fi
 }
 
 main() {


### PR DESCRIPTION
Some commands in the script.sh file will only work in environments that have gnome-terminal installed (linux). If this is not present on the computer, print the instructions so the user can run them manually instead.

Also update the README.md to instruct the user to chmod the setup.sh before running